### PR TITLE
Fixed blade tags for Laravel 5. This breaks compatibility for Laravel 4.

### DIFF
--- a/src/views/table.blade.php
+++ b/src/views/table.blade.php
@@ -1,17 +1,17 @@
 {{-- Let's start generating the table for the collection, first we'll assign the table attributes --}}
-<table @if($collection->eloquentTableAttributes) {{ $collection->eloquentTableAttributes }} @else class="table table-striped" @endif>
+<table @if($collection->eloquentTableAttributes) {!! $collection->eloquentTableAttributes !!} @else class="table table-striped" @endif>
     <thead>
         <tr>
         {{-- Now, let's go through every column and output it's header --}}
         @foreach($collection->eloquentTableColumns as $key => $name)
             {{-- We'll apply the hidden column attributes if the column is meant to be hidden --}}
-            <th {{ $collection->getHiddenColumnAttributes($key) }}>
+            <th {!! $collection->getHiddenColumnAttributes($key) !!}>
             @if(in_array($key, $collection->eloquentTableSort))
                 {{-- If the header key is inside the table sort array, we'll output the sorted link --}}
-                {{ sortableUrlLink($name, array('field' => $key, 'sort'=>'asc')) }}
+                {!! sortableUrlLink($name, array('field' => $key, 'sort'=>'asc')) !!}
             @elseif(array_key_exists($key, $collection->eloquentTableSort))
                 {{-- If the header key is a key inside of the table sort array, we'll output the sorted link --}}
-                {{ sortableUrlLink($name, array('field' => $collection->eloquentTableSort[$key], 'sort'=>'asc')) }}
+                {!! sortableUrlLink($name, array('field' => $collection->eloquentTableSort[$key], 'sort'=>'asc')) !!}
             @else
                 {{-- Looks like we don't have any header modifications, we'll just output the name --}}
                 {{ ucfirst($name) }}
@@ -28,32 +28,32 @@
             {{-- We'll loop through every column we were given --}}
             @foreach($collection->eloquentTableColumns as $key => $name)
                 {{-- Make sure we apply the hidden column attributes to the table data if it's meant to be hidden --}}
-                <td {{ $collection->getHiddenColumnAttributes($key) }}>
+                <td {!! $collection->getHiddenColumnAttributes($key) !!}>
                 {{-- If the column key exists in the table means array, we're outputting a relationship value --}}
                 @if(array_key_exists($key, $collection->eloquentTableMeans))
                     {{-- If the column key also exists in the table modifications array, we're also modifying the relationship object --}}
                     @if(array_key_exists($key, $collection->eloquentTableModifications))
-                        {{
+                        {!!
                             call_user_func_array($collection->eloquentTableModifications[$key], array(
                                 $record->getRelationshipObject($collection->eloquentTableMeans[$key]), $record
                             ))
-                        }}
+                        !!}
                     @else
                         {{-- The column key doesn't exist inside the modifications array, we're just outputting the relationship value --}}
-                        {{ $record->getRelationshipProperty($collection->eloquentTableMeans[$key]) }}
+                        {!! $record->getRelationshipProperty($collection->eloquentTableMeans[$key]) !!}
                     @endif
                 @else
                     {{-- So the column isn't a relationship, let's see if we have to modify the value before displaying it --}}
                     @if(array_key_exists($key, $collection->eloquentTableModifications))
-                        {{ call_user_func_array($collection->eloquentTableModifications[$key], array($record)) }}
+                        {!! call_user_func_array($collection->eloquentTableModifications[$key], array($record)) !!}
                     @else
                         {{-- We don't need to modify the value, let's see if the property exists with the column key first --}}
                         @if($record->{$key})
                             {{-- Great, the key exists on the record, we'll output it here --}}
-                            {{ $record->{$key}  }}
+                            {!! $record->{$key}  !!}
                         @else
                             {{-- Looks like the column key isn't a valid key, we'll try outputting with the column name --}}
-                            {{ $record->{$name}  }}
+                            {!! $record->{$name}  !!}
                         @endif
                     @endif
                 @endif
@@ -66,5 +66,5 @@
 
 {{-- If the method 'showPages' is called, the eloquentTablePages attribute will be true, and we'll display the pages here --}}
 @if($collection->eloquentTablePages)
-    <div class="text-center">{{ $collection->appends(Input::except('page'))->links() }}</div>
+    <div class="text-center">{!! $collection->appends(Input::except('page'))->links() !!}</div>
 @endif


### PR DESCRIPTION
Hi Steve,

The tags in the blade file for the table were incompatible with Laravel 5.

This is because `{{ ... }}` outputs escaped HTML. I have changed them to `{!! ... !!}` in order to output raw HTML.

This breaks compatibility with Laravel 4. The only way I can think to keep compatibility would be to have 2 view files and choose which view depending on the Laravel version (this is messy as you have duplicated view files which will be hard to maintain).

Something I've noticed other packages do is to say that support for Laravel 4 stops at version `1.0.*` and that support for Laravel 5 starts at version `1.1.*`.

I don't know if there is another way to make this work, but here's the updated view file if you want it. This is working for me now.

Many thanks
Thomas Clayson