### PR TITLE
Allow implict table names in models

### DIFF
--- a/src/Stevebauman/EloquentTable/TableTrait.php
+++ b/src/Stevebauman/EloquentTable/TableTrait.php
@@ -388,7 +388,7 @@ trait TableTrait
             /*
              * Retrieve all column names for the current model table
              */
-            $columns = Schema::getColumnListing($this->table);
+            $columns = Schema::getColumnListing($this->getTable());
 
             /*
              * Make sure the field inputted is available on the current table


### PR DESCRIPTION
The current implementation access ->table property directly,
while is recommended access the ->getTable() function, which allows
the use of implict table names (plural of model class name).