### PR TITLE
Only merge with GET parameters

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -47,7 +47,7 @@ if (!function_exists('sortableUrlLink')) {
         }
 
         // Merge the parameters with any get params
-        $parameters = array_merge(Input::except('sort', 'field'), $parameters);
+        $parameters = array_merge(Request::query(), $parameters);
 
         // Now we'll return a link of the current page with the sorting parameters attached
         return sprintf('<a class="link-sort" href="%s">%s <i class="%s"></i></a>', Request::url().'?'.http_build_query($parameters), $title, $icon);


### PR DESCRIPTION
When using this module on a page that has GET and POST variables. All variables GET and POST variables will be added to the query string. This fix will only add the GET variables. Values from the Request::query() array will be overwritten by $parameters array, so sort and field values will be updated correctly.